### PR TITLE
Preserve egg_dir for namespace management

### DIFF
--- a/openalea.sconsx/meta.yaml
+++ b/openalea.sconsx/meta.yaml
@@ -5,6 +5,9 @@ package:
 source:
   git_url: https://github.com/openalea/sconsx
 
+build:
+  preserve_egg_dir: True
+
 requirements:
   build:
     - python


### PR DESCRIPTION
Conda build fail due to a bug in conda/conda-build#1105