### PR TITLE
Move recipe to a branch of openalea/visualea

### DIFF
--- a/openalea.visualea/meta.yaml
+++ b/openalea.visualea/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: https://github.com/openalea/openalea
-
+  git_tag: install_requires
 
 build:
   preserve_egg_dir: True


### PR DESCRIPTION
In the branch install_requires, we remove all the fixed dependencies in setup.py