### PR TITLE
Remove mingw as deps and force qt 4 dependency

### DIFF
--- a/openalea.visualea/meta.yaml
+++ b/openalea.visualea/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - python
     - setuptools
     - openalea.deploy
-    - mingw # [win]
+    #- mingw # [win]
 
   run:
     - python
@@ -25,6 +25,7 @@ requirements:
     - openalea.vpltk
     - openalea.grapheditor
     - openalea.oalab
+    - qt <5
     - pyqt <5
     - ipython ==2.4.1
     - ipython-qtconsole ==2.4.1


### PR DESCRIPTION
Set qt 4 dependency.
This force conda to not install qt 5 even if pyqt is lesser than 5.