### PR TITLE
Caribu

### DIFF
--- a/caribu/bld.bat
+++ b/caribu/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --prefix="%PREFIX%"
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: for a list of environment variables that are set during the build process.

--- a/caribu/build.sh
+++ b/caribu/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install --prefix=$PREFIX

--- a/caribu/build.sh
+++ b/caribu/build.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+scons build_prefix=$SRC_DIR/build-scons build_includedir=$PREFIX/include build_libdir=$PREFIX/lib build_bindir=$PREFIX/bin \
+num_jobs=$CPU_COUNT build
 $PYTHON setup.py install --prefix=$PREFIX

--- a/caribu/meta.yaml
+++ b/caribu/meta.yaml
@@ -4,6 +4,9 @@ package:
 
 source:
   git_url: https://github.com/openalea-incubator/caribu
+  patches:
+   # List any patch files here
+   - setup.py.patch
 
 
 build:
@@ -16,6 +19,7 @@ requirements:
     - openalea.deploy
     - scons
     - openalea.sconsx
+    - path.py
   run:
     - python
     - setuptools
@@ -25,6 +29,7 @@ requirements:
     - matplotlib
     - vplants.plantgl
     - openalea.mtg
+    - path.py
 
 test:
   imports:

--- a/caribu/meta.yaml
+++ b/caribu/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: alinea.caribu
+  version: 7.0.0
+
+source:
+  git_url: https://github.com/openalea-incubator/caribu
+
+
+build:
+  preserve_egg_dir: True
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - openalea.deploy
+    - scons
+    - openalea.sconsx
+  run:
+    - python
+    - setuptools
+    - openalea.deploy
+    - openalea.core
+    - numpy
+    - matplotlib
+    - vplants.plantgl
+    - openalea.mtg
+
+test:
+  imports:
+    - alinea.caribu
+
+about:
+  home: http://openalea.gforge.inria.fr/
+  license: INRA License
+  summary: Eco-physiological model of light interception by plants

--- a/caribu/setup.py.patch
+++ b/caribu/setup.py.patch
@@ -1,0 +1,38 @@
+diff --git a/setup.py b/setup.py
+index 6f153cc..ecdc90e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -10,7 +10,6 @@ from os.path import join as pj
+ 
+ from setuptools import setup, find_packages
+ 
+-
+ short_descr = "Python/Visualea interface to Caribu Light model"
+ readme = open('README.rst').read()
+ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+@@ -52,7 +51,7 @@ setup_kwds = dict(
+ 
+     packages=find_packages('src'),
+     package_dir={'': 'src'},
+-    
++
+     include_package_data=True,
+     package_data={'caribu_data': data_files},
+     install_requires=[
+@@ -73,10 +72,12 @@ setup_kwds = dict(
+ # #}
+ # change setup_kwds below before the next pkglts tag
+ 
+-build_prefix = "build-scons"
+-setup_kwds['scons_scripts'] = ['SConstruct']
+-setup_kwds['bin_dirs'] = {'bin': build_prefix + '/bin'}
+-setup_kwds['entry_points']['wralea'] = ['caribu = alinea.caribu_wralea']
++#build_prefix = "build-scons"
++#setup_kwds['scons_scripts'] = ['SConstruct']
++#setup_kwds['bin_dirs'] = {'bin': build_prefix + '/bin'}
++setup_kwds['entry_points']['wralea'] = ['alinea.caribu = alinea.caribu_wralea']
++setup_kwds['entry_points']["console_scripts"] = []
++setup_kwds['package_data'][''] = ['*.can', '*.R', '*.8', '*.opt', '*.light', '*.csv', '*.png','*.pyd', '*.so', '*.dylib']
+ 
+ # do not change things below
+ # {# pkglts, pysetup.call


### PR DESCRIPTION
Fix a bug in conda-build using a trick:
```
  File "/Users/pradal/miniconda2/lib/python2.7/site-packages/conda_build/build.py", line 784, in build
    entry_point_script_names = get_entry_point_script_names(get_entry_points(config, m))
  File "/Users/pradal/miniconda2/lib/python2.7/site-packages/conda_build/build.py", line 356, in get_entry_points
    for ep in setup_py_entry_points:
TypeError: 'NoneType' object is not iterable
```

Conda-build detect entry-points but was waiting for only console scripts.
I just add it as an empty list as a patch. 