### PR TITLE
Tavis CI with build of boost on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ services:
 env:
  - CONDA_RECIPE=boost
    CONDA_VERSION=2
+   ANACONDA_UPLOAD=openalea
+   ANACONDA_LABEL=unstable
 
 install:
   - git clone https://github.com/OpenAlea/travis-ci.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+sudo: required
+
+services:
+  - docker
+
+env:
+ - CONDA_RECIPE=boost
+   CONDA_VERSION=2
+
+install:
+  - git clone https://github.com/OpenAlea/travis-ci.git
+  - cd travis-ci
+  - source install.sh
+
+before_script:
+  - source before_script.sh
+
+script:
+  - source script.sh
+
+after_success:
+  - source after_success.sh
+
+after_failure:
+  - source after_failure.sh
+
+before_deploy:
+  - source before_deploy.sh
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: bash deploy_script.sh
+
+after_deploy:
+  - source after_deploy.sh
+
+after_script:
+  - source after_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: cpp
+
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: cpp
 
 os:
   - linux
-  - osx
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: cpp
-
 os:
   - linux
   - osx


### PR DESCRIPTION
Not on OSX because it's fail. 

You can look build error  on : https://travis-ci.org/artzet-s/openalea-recipes/jobs/300247181